### PR TITLE
Try flattening the artifacts copy to workaround coupling issue

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,23 @@
+Copyright 2019 Open Microscopy Environment.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/vars/recursiveMerge.groovy
+++ b/vars/recursiveMerge.groovy
@@ -58,7 +58,7 @@ def call(Map pipelineParams) {
     def pushBranch = env.MERGE_PUSH_BRANCH
     def gitUser = env.MERGE_GIT_USER
     def mergeOptions = params.MERGE_OPTIONS
-    def status = params.STATUS
+    def status = params.STATUS ?: "success-only"
 
     // build is in .gitignore so we can use it as a temp dir
     copyArtifacts(projectName: pipelineParams.parentVersions, flatten: true,

--- a/vars/recursiveMerge.groovy
+++ b/vars/recursiveMerge.groovy
@@ -1,3 +1,44 @@
+#!/usr/bin/env groovy
+/**
+ * Copyright 2019 University of Dundee
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+/**
+ * Call the generic script running the recursive merge on one repository and
+ * submodules.
+ *
+ * This script will create a version TSV file under build/version.tsv and
+ * archive it as an artifact of the Jenkins job. It can also consume a
+ * version.tsv generated and archived by a single parent (non-matrix) Jenkins
+ * job.  The name of the location of the parent file can be
+ * specified using {@code pipelineParams.parentVersions} and
+ * {@code pipelineParams.versionFile}.
+ *
+ * @param pipelineParams a map containing parameters that can be passed to the
+ *                       recursive merge call
+ */
 def call(Map pipelineParams) {
 
     if (pipelineParams == null) {

--- a/vars/recursiveMerge.groovy
+++ b/vars/recursiveMerge.groovy
@@ -20,7 +20,7 @@ def call(Map pipelineParams) {
     def status = params.STATUS
 
     // build is in .gitignore so we can use it as a temp dir
-    copyArtifacts(projectName: pipelineParams.parentVersions, flatten: false,
+    copyArtifacts(projectName: pipelineParams.parentVersions, flatten: true,
                     filter: versionFile, target: 'build')
 
     sh "cd build && curl -sfL ${buildInfraUrl} | tar -zxf -"
@@ -29,8 +29,6 @@ def call(Map pipelineParams) {
     sh """
         export BASE_REPO=${baseRepo}
 
-        # Workaround for "unflattened" file, possibly due to matrix
-        find . -path "build/${versionFile}" -exec cp {} build/version.tsv \\;
         export VERSION_LOG=${currentDir}/build/version.tsv
 
         . build/venv/bin/activate


### PR DESCRIPTION
This commit fixes the coupling between the various stacks built in http://github.com/ome/devspace.

The changes made here are based on a few assumptions for every job invoking the  `jenkins-library-recursivemerge` pipeline scripts:

- each push job consuming the `recursiveMerge` script can depend on another parent job. The parent job should not be a matrix job and should be another push job.
- if a dependency between jobs is declared, the parent job should archive at least a TSV version file. If the parent job is using `jenkins-library-recursive-merge`, this file will be under `build/version.tsv`. Otherwise, the path to the artifact can be specified using `versionFile`

Under this assumption it should be sufficient to copy the single version file flattened directly under `build/version.tsv`. An associated devspace PR should demonstrate this workflow