### PR TITLE
Handling no parentVersions

### DIFF
--- a/vars/recursiveCheckout.groovy
+++ b/vars/recursiveCheckout.groovy
@@ -11,7 +11,7 @@ def call(Map pipelineParams) {
 
     checkout poll: false,
            scm: [$class: 'GitSCM',
-                 branches: [[name: '*/${branch}']],
+                 branches: [[name: "*/${branch}"]],
                  doGenerateSubmoduleConfigurations: false,
                  extensions: [[$class: 'CleanCheckout'],
                               [$class: 'SubmoduleOption', disableSubmodules: false, parentCredentials: false, recursiveSubmodules: true, reference: '', trackingSubmodules: false]],

--- a/vars/recursiveCheckout.groovy
+++ b/vars/recursiveCheckout.groovy
@@ -7,10 +7,11 @@ def call(Map pipelineParams) {
     def fork = pipelineParams.fork ?: "ome"
     def repo = pipelineParams.repo ?: "unknown"
     def url = pipelineParams.url ?: "git://github.com/${fork}/${repo}"
+    def branch = pipelineParams.branch ?: "master"
 
     checkout poll: false,
            scm: [$class: 'GitSCM',
-                 branches: [[name: '*/master']],
+                 branches: [[name: '*/${branch}']],
                  doGenerateSubmoduleConfigurations: false,
                  extensions: [[$class: 'CleanCheckout'],
                               [$class: 'SubmoduleOption', disableSubmodules: false, parentCredentials: false, recursiveSubmodules: true, reference: '', trackingSubmodules: false]],

--- a/vars/recursiveMerge.groovy
+++ b/vars/recursiveMerge.groovy
@@ -60,9 +60,11 @@ def call(Map pipelineParams) {
     def mergeOptions = params.MERGE_OPTIONS
     def status = params.STATUS ?: "success-only"
 
-    // build is in .gitignore so we can use it as a temp dir
-    copyArtifacts(projectName: pipelineParams.parentVersions, flatten: true,
-                    filter: versionFile, target: 'build')
+    if (pipelineParams.parentVersions != null) {
+        // build is in .gitignore so we can use it as a temp dir
+        copyArtifacts(projectName: pipelineParams.parentVersions, flatten: true,
+                        filter: versionFile, target: 'build')
+    }
 
     sh "cd build && curl -sfL ${buildInfraUrl} | tar -zxf -"
     sh "virtualenv build/venv && build/venv/bin/pip install scc"

--- a/vars/recursiveMerge.groovy
+++ b/vars/recursiveMerge.groovy
@@ -51,6 +51,7 @@ def call(Map pipelineParams) {
     def buildInfraPath = pipelineParams.buildInfraPath ?: "build-infra-${buildInfraBranch}"
 
     def baseRepo = pipelineParams.baseRepo ?: "unknown.git"
+    def baseBranch = pipelineParams.baseBranch ?: "master"
     def versionFile = pipelineParams.versionFile ?: "build/version.tsv"
 
     // environment
@@ -73,6 +74,7 @@ def call(Map pipelineParams) {
 
     sh """
         export BASE_REPO=${baseRepo}
+        export BASE_BRANCH=${baseBranch}
 
         export VERSION_LOG=${currentDir}/build/version.tsv
 

--- a/vars/recursiveMerge.groovy
+++ b/vars/recursiveMerge.groovy
@@ -64,6 +64,8 @@ def call(Map pipelineParams) {
         // build is in .gitignore so we can use it as a temp dir
         copyArtifacts(projectName: pipelineParams.parentVersions, flatten: true,
                         filter: versionFile, target: 'build')
+    } else {
+        sh "mkdir -p build"
     }
 
     sh "cd build && curl -sfL ${buildInfraUrl} | tar -zxf -"


### PR DESCRIPTION
The current set-up of https://github.com/ome/devspace/releases/tag/0.13.0 defines push jobs coupled to each other using the `parentVersions` parameter.

In some conditions, a push job might have no parent e.g. if some upstream jobs are disabled in the pipeline or eventually when the most upstream job (currently BIOFORMATS-push) gets upgraded to use jenkins-library-recursivemerge.

Currently this situation fails with a NPE. This change adds support for empty `parentVersions` parameters. Note other places e.g. https://github.com/ome/omero-build/blob/v5.5.2/Jenkinsfile#L20 might need to be adjusted to support this workflow.