### PR TITLE
recursiveMerge: ignore the build directory

### DIFF
--- a/vars/recursiveMerge.groovy
+++ b/vars/recursiveMerge.groovy
@@ -68,7 +68,10 @@ def call(Map pipelineParams) {
         copyArtifacts(projectName: pipelineParams.parentVersions, flatten: true,
                         filter: versionFile, target: 'build')
     } else {
-        sh "mkdir -p build"
+        sh """
+        mkdir -p build
+        echo build > .git/info/exclude
+        """
     }
 
     sh """


### PR DESCRIPTION
scc regularly fails on new repositories where a checkout has been
performed and then the "build" directory is created but is not
present in the .gitignore file. This uses the local
.git/info/exclude to prevent any errors.

cc: @sbesson 
see: https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-server-docker-push/3/console